### PR TITLE
feat: handle 520 status code on get

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const { addMilliseconds } = require('date-fns')
-const getTime = require('date-fns/getTime')
-const pReflect = require('p-reflect')
+const { addMilliseconds, getTime } = require('date-fns')
 const EventEmitter = require('events')
+const pReflect = require('p-reflect')
 const AWS = require('aws-sdk')
 const got = require('got')
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "s3"
   ],
   "dependencies": {
-    "date-fns": "~2.16.0",
+    "date-fns": "~2.16.1",
     "p-reflect": "~2.1.0"
   },
   "devDependencies": {

--- a/test/get.js
+++ b/test/get.js
@@ -20,7 +20,7 @@ test("if key doesn't exist, returns undefined", async t => {
 test('if key exists, returns the value', async t => {
   const key = 'foo2'
   const value = 'bar2'
-  const ttl = 1000
+  const ttl = 5000
 
   await keyvS3.set(key, value, ttl)
   t.is(await keyvS3.get(key), value)


### PR DESCRIPTION
after observing

```
HTTPError: Response code 520 (undefined)
```

on production servers, `keyv-s3` should be tolerant under `520` status code