### PR TITLE
chore: lock aws-sdk version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,12 @@
+audit=false
+fund=false
+loglevel=error
+package-lock=false
+prefer-dedupe=true
+prefer-offline=false
+resolution-mode=highest
 save-prefix=~
+save=false
+shamefully-hoist=true
+strict-peer-dependencies=false
+unsafe-perm=true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "p-reflect": "~2.1.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "latest",
+    "@aws-sdk/client-s3": "3.726.1",
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
     "@ksmithut/prettier-standard": "latest",


### PR DESCRIPTION
backblaze doesn't support x-amz-checksum-crc32

check: https://www.backblaze.com/docs/cloud-storage-use-the-aws-sdk-for-javascript-v3-with-backblaze-b2